### PR TITLE
Added fix to catch unexpected bundle coding formats

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -149,10 +149,10 @@ export function performCodeMapping(
 function mapCoding(coding: Coding, resourceType: string) {
   // Check all the codes for conversion based on the given mapping.
   let count = 0;
-    // Check if coding is undefined in the event of an unexpected bundle format. If so, skip this resource.
-    if (coding == undefined) {
-      return;
-    }
+  // Check if coding is undefined in the event of an unexpected bundle format. If so, skip this resource.
+  if (coding == undefined) {
+    return;
+  }
   for (const currentCoding of coding.coding) {
     const origSystem: string = currentCoding.system;
     let resultSystem = "http://snomed.info/sct";

--- a/src/query.ts
+++ b/src/query.ts
@@ -149,6 +149,10 @@ export function performCodeMapping(
 function mapCoding(coding: Coding, resourceType: string) {
   // Check all the codes for conversion based on the given mapping.
   let count = 0;
+    // Check if coding is undefined in the event of an unexpected bundle format. If so, skip this resource.
+    if (coding == undefined) {
+      return;
+    }
   for (const currentCoding of coding.coding) {
     const origSystem: string = currentCoding.system;
     let resultSystem = "http://snomed.info/sct";


### PR DESCRIPTION
This PR adds a catch-all to the medical coding mapping code in the event of an unexpected patient bundle format.

Pull requests into the clinical-trial-matching-service-breastcancertrials.org require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrapper template?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
