### PR TITLE
Update to use latest service library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,13 +1061,14 @@
     },
     "node_modules/clinical-trial-matching-service": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
+      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#49a38a4dfdbf623c2631a96059fd19be9d74603c",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "extract-zip": "^2.0.1",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "yauzl": "^2.10.0"
       }
     },
     "node_modules/cliui": {
@@ -1648,7 +1649,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -4922,13 +4922,14 @@
       "dev": true
     },
     "clinical-trial-matching-service": {
-      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
+      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#49a38a4dfdbf623c2631a96059fd19be9d74603c",
       "from": "clinical-trial-matching-service@github:mcode/clinical-trial-matching-service",
       "requires": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "extract-zip": "^2.0.1",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "yauzl": "^2.10.0"
       }
     },
     "cliui": {

--- a/spec/query.spec.ts
+++ b/spec/query.spec.ts
@@ -1,4 +1,4 @@
-import { ClinicalTrialGovService, ClinicalTrialMatcher, fhir } from "clinical-trial-matching-service";
+import { ClinicalTrialsGovService, ClinicalTrialMatcher, fhir } from "clinical-trial-matching-service";
 import { APIError, createClinicalTrialLookup, performCodeMapping, sendQuery, updateResearchStudy } from "../src/query";
 import nock from "nock";
 import {
@@ -12,7 +12,7 @@ import { createExampleTrialResponse, createEmptyClinicalStudy, createEmptyBundle
 
 describe(".createClinicalTrialLookup", () => {
   it("raises an error if missing an endpoint", () => {
-    const backupService = new ClinicalTrialGovService("temp");
+    const backupService = new ClinicalTrialsGovService("temp");
     expect(() => {
       createClinicalTrialLookup({}, backupService);
     }).toThrowError("Missing API_ENDPOINT in configuration");
@@ -20,19 +20,19 @@ describe(".createClinicalTrialLookup", () => {
 
   it("creates a function", () => {
     expect(
-      typeof createClinicalTrialLookup({ api_endpoint: "http://www.example.com/" }, new ClinicalTrialGovService("temp"))
+      typeof createClinicalTrialLookup({ api_endpoint: "http://www.example.com/" }, new ClinicalTrialsGovService("temp"))
     ).toEqual("function");
   });
 
   describe("generated matcher function", () => {
     const endpoint = "http://www.example.com/endpoint";
     let matcher: ClinicalTrialMatcher;
-    let backupService: ClinicalTrialGovService;
+    let backupService: ClinicalTrialsGovService;
     let scope: nock.Scope;
     let interceptor: nock.Interceptor;
     beforeEach(() => {
       // Note: backupService is never initialized therefore it won't actually work
-      backupService = new ClinicalTrialGovService("temp");
+      backupService = new ClinicalTrialsGovService("temp");
       // Don't actually download anything
       spyOn(backupService, "updateResearchStudies").and.callFake((studies) => {
         return Promise.resolve(studies);

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,7 +5,7 @@
 
 import {
   ClinicalStudy,
-  ClinicalTrialGovService,
+  ClinicalTrialsGovService,
   fhir,
   SearchSet,
   ServiceConfiguration,
@@ -67,7 +67,7 @@ export function updateResearchStudy(researchStudy: fhir.ResearchStudy, clinicalS
  */
 export function createClinicalTrialLookup(
   configuration: QueryConfiguration,
-  backupService: ClinicalTrialGovService
+  backupService: ClinicalTrialsGovService
 ): (patientBundle: Bundle) => Promise<SearchSet> {
   // Raise errors on missing configuration
   if (typeof configuration.api_endpoint !== "string") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,18 +3,18 @@
 import { createClinicalTrialLookup } from "./query";
 import ClinicalTrialMatchingService, {
   configFromEnv,
-  ClinicalTrialGovService,
+  ClinicalTrialsGovService,
 } from "clinical-trial-matching-service";
-import { importRxnormSnomedMapping, importStageSnomedMapping, importStageAjccMapping, importLoincBiomarkerMapping, importSnomedHl7Mapping  } from "./breastcancertrials";
+import { importRxnormSnomedMapping, importStageSnomedMapping, importStageAjccMapping, importLoincBiomarkerMapping, importSnomedHl7Mapping } from "./breastcancertrials";
 import * as dotenv from "dotenv-flow";
 
 export class BreastCancerTrialsService extends ClinicalTrialMatchingService {
-  backupService: ClinicalTrialGovService;
+  backupService: ClinicalTrialsGovService;
   constructor(config: Record<string, string | number>) {
     // Need to instantiate the backup service first - note that it is NOT
     // initialized here
     // TODO: Make this configurable
-    const backupService = new ClinicalTrialGovService(
+    const backupService = new ClinicalTrialsGovService(
       "clinicaltrial-backup-cache"
     );
     super(createClinicalTrialLookup(config, backupService), config);


### PR DESCRIPTION
Update to use the version of the service library that caches clinical trial data to the file system.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrapper template?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
