### PR TITLE
Add Likelihood for BCT

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Default environment
 
 # Endpoint for your api
-API_ENDPOINT=http://www.ctmatchsandbox.org/mitre-service-v1/services/bctmatch/bundle/trials 
+API_ENDPOINT=https://www.ctmatch.org/mitre-service-v1/services/bctmatch/bundle/trials
 PORT=3000
 
 # Create an .env.local file to set the auth token

--- a/spec/query.spec.ts
+++ b/spec/query.spec.ts
@@ -20,12 +20,12 @@ describe(".createClinicalTrialLookup", () => {
 
   it("creates a function", () => {
     expect(
-      typeof createClinicalTrialLookup({ api_endpoint: "http://www.example.com/" }, new ClinicalTrialsGovService("temp"))
+      typeof createClinicalTrialLookup({ api_endpoint: "https://www.example.com/" }, new ClinicalTrialsGovService("temp"))
     ).toEqual("function");
   });
 
   describe("generated matcher function", () => {
-    const endpoint = "http://www.example.com/endpoint";
+    const endpoint = "https://www.example.com/endpoint";
     let matcher: ClinicalTrialMatcher;
     let backupService: ClinicalTrialsGovService;
     let scope: nock.Scope;
@@ -38,7 +38,7 @@ describe(".createClinicalTrialLookup", () => {
         return Promise.resolve(studies);
       });
       matcher = createClinicalTrialLookup({ api_endpoint: endpoint }, backupService);
-      scope = nock("http://www.example.com");
+      scope = nock("https://www.example.com");
       interceptor = scope.post("/endpoint");
     });
     afterEach(() => {
@@ -225,9 +225,9 @@ describe("updateResearchStudy()", () => {
 describe(".sendQuery", () => {
   let scope: nock.Scope;
   let interceptor: nock.Interceptor;
-  const endpoint = "http://www.example.com/endpoint";
+  const endpoint = "https://www.example.com/endpoint";
   beforeEach(() => {
-    scope = nock("http://www.example.com");
+    scope = nock("https://www.example.com");
     interceptor = scope.post("/endpoint");
   });
   afterEach(() => {


### PR DESCRIPTION
Results that comeback from BCT are a match (as BCT doesn't return results that are not a match). Thus, results should be added to the search set with a match score of 1 to be utilized in the engine (for sorting reasons).

This PR adds the results to the SearchSet with a score of 1.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrapper template?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
