### PR TITLE
Add Docker config to run within a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/node_modules
+/dist
+/dist-spec
+/.nyc_output
+/coverage
+/ctgov-cache.db

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # Ignore installed modules
 /node_modules
+
+# Ignore cache
 /ctgov-cache.db
 
 # Ignore Instanbul coverage files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+# Base image - installs dependencies
+FROM node:20 AS base
+
+# Declare wrapper directory (mainly intended for use by other scripts)
+ENV WRAPPER_DIR=/ctm-bct
+# Port used
+ENV WRAPPER_PORT=3000
+
+FROM base AS builder
+
+WORKDIR ${WRAPPER_DIR}
+COPY . .
+RUN npm ci
+
+# Runner stage
+FROM base as runner
+WORKDIR ${WRAPPER_DIR}
+ENV NODE_ENV production
+
+# Create a non-root user to run as
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nodejs
+
+COPY package.json package-lock.json ./
+# Because this is a local copy, we can modify it. Remove the prepare script -
+# otherwise NPM will attempt to run it, even in production mode, which appears
+# to be a bug that will never be fixed
+# (see https://github.com/npm/cli/issues/4027)
+RUN npm pkg delete scripts.prepare
+RUN npm ci
+# For some reason this
+# The local* thing is effectively a way of saying "if exists"
+COPY ./.env ./.env.local* ./.env.production.local* ./start.js ./
+COPY ./data/ ./data/
+# Copy final code over from the builder
+COPY --from=builder /${WRAPPER_DIR}/dist ./dist/
+
+# Create a cache directory - Sqlite needs to be able to write to the cache dir
+# for some reason
+RUN mkdir ./ctgov-cache
+RUN chown nodejs:nodejs ./ctgov-cache
+ENV CTGOV_CACHE_FILE=${WRAPPER_DIR}/ctgov-cache/ctgov-cache.db
+
+USER nodejs
+EXPOSE ${WRAPPER_PORT}
+
+CMD [ "node", "start.js" ]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "coverage": "npm run-script build:tests && nyc --require ts-node/register --reporter=lcovonly jasmine",
     "coverage:html": "npm run-script build:tests && nyc --require ts-node/register --reporter=html jasmine",
     "lint": "eslint . --ext .js,.ts",
+    "prepare": "npm run build",
     "serve": "npm run build && node start.js",
     "start": "npm run serve",
     "test": "npm run-script build:tests && npm run-script test:run",


### PR DESCRIPTION
Adds a Dockerfile which allows the container to be built and run within a Docker container. (Also does some minor changes, like adding the build script to the "prepare" script, which NPM runs on `npm install` to build the container.)